### PR TITLE
Only process new NfcTag intents

### DIFF
--- a/Source/Poz1.NFCForms.Droid/NfcForms.cs
+++ b/Source/Poz1.NFCForms.Droid/NfcForms.cs
@@ -89,24 +89,26 @@ namespace Poz1.NFCForms.Droid
 		public void OnNewIntent (object sender, Intent e)
 		{
 		    droidTag = e.GetParcelableExtra(NfcAdapter.ExtraTag) as Tag;
-
+		    if (droidTag != null)
+		    {
 			nfcTag.TechList = new List<string>(droidTag.GetTechList());
-			nfcTag.Id = droidTag.GetId();
-
+			nfcTag.Id = droidTag.GetId()
+			
 			if (GetNdef (droidTag) == null) 
 			{
-				nfcTag.IsNdefSupported = false;
+			    nfcTag.IsNdefSupported = false;
 			}
 			else 
 			{
-				nfcTag.IsNdefSupported = true;
-				Ndef ndef = GetNdef (droidTag);
-				nfcTag.NdefMessage = ReadNdef (ndef);
-				nfcTag.IsWriteable = ndef.IsWritable;
-				nfcTag.MaxSize = ndef.MaxSize;
+			    nfcTag.IsNdefSupported = true;
+			    Ndef ndef = GetNdef (droidTag);
+			    nfcTag.NdefMessage = ReadNdef (ndef);
+			    nfcTag.IsWriteable = ndef.IsWritable;
+			    nfcTag.MaxSize = ndef.MaxSize;
 			}
 
 			RaiseNewTag(nfcTag);
+		    }
 		}
 
 		public void WriteTag (NdefLibrary.Ndef.NdefMessage message)

--- a/Source/Poz1.NFCForms.Droid/NfcForms.cs
+++ b/Source/Poz1.NFCForms.Droid/NfcForms.cs
@@ -92,7 +92,7 @@ namespace Poz1.NFCForms.Droid
 		    if (droidTag != null)
 		    {
 			nfcTag.TechList = new List<string>(droidTag.GetTechList());
-			nfcTag.Id = droidTag.GetId()
+			nfcTag.Id = droidTag.GetId();
 			
 			if (GetNdef (droidTag) == null) 
 			{


### PR DESCRIPTION
If `OnNewIntent` is called with no `Android.Nfc.Tag` as extra, null reference was thrown. With the change, the intent is only processed if the extra is of type `Android.Nfc.Tag`.